### PR TITLE
Add ArableClient class to the arablepy namespace

### DIFF
--- a/arablepy/__init__.py
+++ b/arablepy/__init__.py
@@ -1,1 +1,1 @@
-# from arablepy import ArableClient
+from .arablepy import ArableClient


### PR DESCRIPTION
Tells python to add the ArableClient class from the arable.py module into the actual arablepy package namespace when importing it